### PR TITLE
Change Default port for local preview to 8080.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -123,3 +123,14 @@ simple_jekyll_search:
 # ---------------- #
 google:
     analytics_id: UA-80669434-1
+
+# ---------------- #
+#  Avoid github    #
+# authentication   #
+#      error       #
+github: [metadata]
+
+# ---------------- #
+#     Serving      #
+# ---------------- #
+port: 8088


### PR DESCRIPTION
Avoid permission denied issue. Port 4000 often ocupied by
FoxiReader.exe